### PR TITLE
use regex to match ipv4 addr from response

### DIFF
--- a/DnsTube/Utility.cs
+++ b/DnsTube/Utility.cs
@@ -32,7 +32,7 @@ namespace DnsTube
 						candidatePublicIpAddress = regex.Match(response).Value;
 					}
 
-                    if (!IsValidIpAddress(protocol, candidatePublicIpAddress))
+					if (!IsValidIpAddress(protocol, candidatePublicIpAddress))
 						throw new Exception($"Malformed response, expected IP address: {response}");
 
 					publicIpAddress = candidatePublicIpAddress;

--- a/DnsTube/Utility.cs
+++ b/DnsTube/Utility.cs
@@ -26,8 +26,13 @@ namespace DnsTube
 					attempts++;
 					var response = await Client.GetStringAsync(url);
 					var candidatePublicIpAddress = response.Replace("\n", "");
+					var regex = new Regex("(\\b25[0-5]|\\b2[0-4][0-9]|\\b[01]?[0-9][0-9]?)(\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}");
+					if (regex.IsMatch(candidatePublicIpAddress))
+					{
+						candidatePublicIpAddress = regex.Match(response).Value;
+					}
 
-					if (!IsValidIpAddress(protocol, candidatePublicIpAddress))
+                    if (!IsValidIpAddress(protocol, candidatePublicIpAddress))
 						throw new Exception($"Malformed response, expected IP address: {response}");
 
 					publicIpAddress = candidatePublicIpAddress;


### PR DESCRIPTION
some api dont directly response the ipv4 address, like:

* https://api.live.bilibili.com/client/v1/Ip/getInfoNew

so use regex to match.

```regex
(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}
```